### PR TITLE
Added service, controller and routes for followers functionality

### DIFF
--- a/back/app.js
+++ b/back/app.js
@@ -2,6 +2,7 @@ import express from "express";
 import morgan from "morgan";
 import cors from "cors";
 import authRouter from "./routes/authRouter.js";
+import followRouter from "./routes/followRouter.js";
 
 import "./db/sync.js";
 import recipeRouter from "./routers/recipeRouter.js";
@@ -20,7 +21,8 @@ app.use(express.static("public"));
 
 app.use("/api/recipes", controllerWrapper(recipesRouter));
 app.use("/api/auth", authRouter);
-app.use('/api', controllerWrapper(apiRouter));
+app.use("/api/follow", followRouter);
+app.use("/api", controllerWrapper(apiRouter));
 
 app.use((_, res) => {
   res.status(404).json({ message: "Route not found" });

--- a/back/controllers/followControllers.js
+++ b/back/controllers/followControllers.js
@@ -1,0 +1,84 @@
+import followService from "../services/followServices.js";
+import HttpError from "../helpers/HttpError.js";
+
+// Get users who follow the authenticated user's profile
+export const getFollowers = async (req, res, next) => {
+  try {
+    const userId = req.user.id;
+    const followers = await followService.getFollowers(userId);
+
+    res.json({
+      followers: followers.map((follower) => ({
+        id: follower.id,
+        name: follower.name,
+        email: follower.email,
+        avatar: follower.avatar,
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Get users that the authenticated user is following
+export const getFollowing = async (req, res, next) => {
+  try {
+    const userId = req.user.id;
+    const following = await followService.getFollowing(userId);
+
+    res.json({
+      following: following.map((followee) => ({
+        id: followee.id,
+        name: followee.name,
+        email: followee.email,
+        avatar: followee.avatar,
+      })),
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Add a user to the authenticated user's following list
+export const followUser = async (req, res, next) => {
+  try {
+    const followerId = req.user.id;
+    const { followeeId } = req.params;
+
+    if (followerId === parseInt(followeeId)) {
+      throw HttpError(400, "Cannot follow yourself");
+    }
+
+    const result = await followService.followUser(followerId, followeeId);
+
+    if (!result) {
+      throw HttpError(404, "User not found");
+    }
+
+    res.status(201).json({
+      message: "Successfully started following user",
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Remove a user from the authenticated user's following list
+export const unfollowUser = async (req, res, next) => {
+  try {
+    const followerId = req.user.id;
+    const { followeeId } = req.params;
+
+    const result = await followService.unfollowUser(followerId, followeeId);
+
+    if (!result) {
+      throw HttpError(404, "Follow relationship not found");
+    }
+
+    res.json({
+      message: "Successfully unfollowed user",
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/back/routes/followRouter.js
+++ b/back/routes/followRouter.js
@@ -1,0 +1,24 @@
+import express from "express";
+import authenticate from "../middlewares/authenticate.js";
+import {
+  getFollowers,
+  getFollowing,
+  followUser,
+  unfollowUser,
+} from "../controllers/followControllers.js";
+
+const followRouter = express.Router();
+
+// Get users who follow the authenticated user
+followRouter.get("/followers", authenticate, getFollowers);
+
+// Get users that the authenticated user is following
+followRouter.get("/following", authenticate, getFollowing);
+
+// Follow a user
+followRouter.post("/follow/:followeeId", authenticate, followUser);
+
+// Unfollow a user
+followRouter.delete("/unfollow/:followeeId", authenticate, unfollowUser);
+
+export default followRouter;

--- a/back/services/followServices.js
+++ b/back/services/followServices.js
@@ -1,0 +1,79 @@
+import { User, UserFollow } from "../db/models/users.js";
+
+// Get users who follow the specified user
+async function getFollowers(userId) {
+  const user = await User.findByPk(userId, {
+    include: [
+      {
+        model: User,
+        as: "followers",
+        attributes: ["id", "name", "email", "avatar"],
+      },
+    ],
+  });
+
+  return user ? user.followers : [];
+}
+
+// Get users that the specified user is following
+async function getFollowing(userId) {
+  const user = await User.findByPk(userId, {
+    include: [
+      {
+        model: User,
+        as: "followees",
+        attributes: ["id", "name", "email", "avatar"],
+      },
+    ],
+  });
+
+  return user ? user.followees : [];
+}
+
+// Create a follow relationship
+async function followUser(followerId, followeeId) {
+  // Check if the followee user exists
+  const followee = await User.findByPk(followeeId);
+  if (!followee) {
+    return null;
+  }
+
+  // Check if the relationship already exists
+  const existingFollow = await UserFollow.findOne({
+    where: {
+      follower_user_id: followerId,
+      followee_user_id: followeeId,
+    },
+  });
+
+  if (existingFollow) {
+    return existingFollow; // Already following
+  }
+
+  // Create the follow relationship
+  const follow = await UserFollow.create({
+    follower_user_id: followerId,
+    followee_user_id: followeeId,
+  });
+
+  return follow;
+}
+
+// Remove a follow relationship
+async function unfollowUser(followerId, followeeId) {
+  const result = await UserFollow.destroy({
+    where: {
+      follower_user_id: followerId,
+      followee_user_id: followeeId,
+    },
+  });
+
+  return result > 0;
+}
+
+export default {
+  getFollowers,
+  getFollowing,
+  followUser,
+  unfollowUser,
+};


### PR DESCRIPTION
This PR implements a complete user following system with four private endpoints that allow users to follow/unfollow each other and view their followers/following lists.

## ✨ Features Added

### 🔐 Private Endpoints (All require authentication)

1. **Get Followers** - `GET /api/follow/followers`

   - Returns users who follow the authenticated user
   - Response: List of user objects with `id`, `name`, `email`, `avatar`

2. **Get Following** - `GET /api/follow/following`

   - Returns users that the authenticated user is following
   - Response: List of user objects with `id`, `name`, `email`, `avatar`

3. **Follow User** - `POST /api/follow/follow/:followeeId`

   - Adds a user to the authenticated user's following list
   - Prevents self-following
   - Handles duplicate follow attempts gracefully
   - Response: Success message

4. **Unfollow User** - `DELETE /api/follow/unfollow/:followeeId`
   - Removes a user from the authenticated user's following list
   - Response: Success message or 404 if relationship doesn't exist